### PR TITLE
lib/neutron: Fix conf handling

### DIFF
--- a/lib/neutron
+++ b/lib/neutron
@@ -399,9 +399,9 @@ function start_neutron_api {
         service_protocol="http"
     fi
 
-    local opts = ""
-    opts+="--config-file $NEUTRON_CONF"
-    opts+="--config-file $NEUTRON_CORE_PLUGIN_CONF"
+    local opts=""
+    opts+=" --config-file $NEUTRON_CONF"
+    opts+=" --config-file $NEUTRON_CORE_PLUGIN_CONF"
     local cfg_file
     for cfg_file in ${_NEUTRON_SERVER_EXTRA_CONF_FILES_ABS[@]}; do
         opts+=" --config-file $cfg_file"
@@ -409,7 +409,7 @@ function start_neutron_api {
 
     # Start the Neutron service
     # TODO(sc68cal) Stop hard coding this
-    run_process neutron-api "$NEUTRON_BIN_DIR/neutron-server $ops"
+    run_process neutron-api "$NEUTRON_BIN_DIR/neutron-server $opts"
 
     if is_ssl_enabled_service "neutron"; then
         ssl_ca="--ca-certificate=${SSL_BUNDLE_FILE}"


### PR DESCRIPTION
- Remove extra spaces
- Fix a missing space in the generated option string
- Fix a fatal typo

Change-Id: Ieca1c3e3c7e2ff59089ef45435e126ce7ff4f9b5
Closes-Bug: #1667073
(cherry picked from commit ed887d8b9f91f8c75b45770d5c250b9939f36619)